### PR TITLE
fix(head.html): add noindex meta tag for 404 pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,10 @@
     content="width=device-width, user-scalable=no initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
   >
 
+  {% if page.title == "404: Page not found" %}
+    <meta name="robots" content="noindex, nofollow">
+  {% endif %}
+
   {%- capture seo_tags -%}
     {% seo title=false %}
   {%- endcapture -%}


### PR DESCRIPTION
# Type of change

<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
Removes pages were returning 404 accordingly but without the `noindex` tag, what makes Google always complain that the page could not be indexed. The pages were asked to be removed from Google and no the tag is added.

## Additional context
<!-- e.g. Fixes #(issue) -->
